### PR TITLE
Fixed Search functions and Partner URLs

### DIFF
--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.on_aol" name="On Aol" version="1.0.0" provider-name="divingmule">
+<addon id="plugin.video.on_aol" name="On Aol" version="1.0.2" provider-name="divingmule">
   <requires>
     <import addon="xbmc.python" version="2.0"/>
     <import addon="script.module.beautifulsoup" version="3.0.8"/>

--- a/addon.xml
+++ b/addon.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="plugin.video.on_aol" name="On Aol" version="1.0.2" provider-name="divingmule">
   <requires>
-    <import addon="xbmc.python" version="2.0"/>
+    <import addon="xbmc.python" version="2.1.0"/>
     <import addon="script.module.beautifulsoup" version="3.0.8"/>
     <import addon="script.common.plugin.cache" version="1.3.0"/>
     <import addon="script.module.simplejson" version="2.0.10"/>

--- a/default.py
+++ b/default.py
@@ -291,7 +291,7 @@ def search(search_url):
             search_query = keyboard.getText()
             if len(search_query) == 0:
                 return
-            search_url = ('http://on.aol.com/ajax/GetSearchPageResults/%s/%s/1/relevance/'
+            search_url = ('http://on.aol.com/ajax/search/GetSearchPageResults/%s/%s/1/relevance/'
                           %(urllib.quote(search_query), search_url))
             if save_search:
                 add_search(search_query, search_url)

--- a/default.py
+++ b/default.py
@@ -228,7 +228,7 @@ def resolve_url(url):
             '2': ['_64.webm', '_4.mp4'],
             '3': [ '_8.mp4']
             }
-        playlist_id = url.split('-')[-1]
+        playlist_id = re.split('-|=', url)[-1]
         json_url = (
             'http://syn.5min.com/handlers/SenseHandler.ashx?func=GetResults&sid=577&isPlayerSeed=true&playlist='+playlist_id+
             '&videoCount=1&autoStart=true&cbCustomID=fiveMinCB_videos_companion&relatedMode=0&videoControlDisplayColor=3355443'

--- a/default.py
+++ b/default.py
@@ -299,7 +299,7 @@ def search(search_url):
         data = json.loads(make_request(search_url))
         partner = False
         if 'Partners' in search_url:
-            key = 'Studios'
+            key = 'Partners'
             partner = True
         else: key = 'Videos'
         total = data[key]['Total']


### PR DESCRIPTION
Search wasn't working before.  I've updated the search url (which likely added /search/) and then also changed the key used in the JSON from Studios to Partners (was likely updated later).  Partner video pages were using a different url format, so I tuned the url parsing with re.split and was able to pull the correct video id that way.  Great addon; glad I could make some simple fixes.
